### PR TITLE
Add annotation-based strategy lookup

### DIFF
--- a/yml/src/main/java/ai/core/strategy/impl/header/DeepSeekHeaderBuilder.java
+++ b/yml/src/main/java/ai/core/strategy/impl/header/DeepSeekHeaderBuilder.java
@@ -5,7 +5,7 @@ import cn.hutool.json.JSONObject;
 import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.HeaderBuilderStrategy;
 import com.iflytek.obu.mark.ai.utils.MapUtils;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-@Component
+@AiModelStrategy(modelType = "DeepSeek", type = AiModelStrategy.StrategyType.HEADER_BUILDER)
 public class DeepSeekHeaderBuilder implements HeaderBuilderStrategy {
 
     @Override

--- a/yml/src/main/java/ai/core/strategy/impl/header/ZhyDeepseekHeaderBuilder.java
+++ b/yml/src/main/java/ai/core/strategy/impl/header/ZhyDeepseekHeaderBuilder.java
@@ -4,7 +4,7 @@ import com.iflytek.obu.mark.ai.config.ModelConfig;
 import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.HeaderBuilderStrategy;
 import com.iflytek.obu.mark.ai.utils.MapUtils;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 import javax.annotation.Resource;
 import javax.crypto.Mac;
@@ -18,7 +18,7 @@ import java.util.*;
  * @author hxdu5
  * @since 2025/7/9 17:34
  */
-@Component
+@AiModelStrategy(modelType = "中海油-DS", type = AiModelStrategy.StrategyType.HEADER_BUILDER)
 public class ZhyDeepseekHeaderBuilder implements HeaderBuilderStrategy {
 
     @Resource

--- a/yml/src/main/java/ai/core/strategy/impl/parser/DeepSeekParser.java
+++ b/yml/src/main/java/ai/core/strategy/impl/parser/DeepSeekParser.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.ModelResponseParser;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 
 /**
  * @author hxdu5
  * @since 2025/7/11 16:02
  */
-@Component("DeepSeek")
+@AiModelStrategy(modelType = "DeepSeek", type = AiModelStrategy.StrategyType.RESPONSE_PARSER)
 public class DeepSeekParser implements ModelResponseParser {
 
     private final ObjectMapper mapper = new ObjectMapper();

--- a/yml/src/main/java/ai/core/strategy/impl/parser/ZhyDeepSeekParser.java
+++ b/yml/src/main/java/ai/core/strategy/impl/parser/ZhyDeepSeekParser.java
@@ -4,7 +4,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.ModelResponseParser;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 /**
  * 中海油DeepSeek解析器
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
  * @author hxdu5
  * @since 2025/7/11 16:03
  */
-@Component("中海油-DS")
+@AiModelStrategy(modelType = "中海油-DS", type = AiModelStrategy.StrategyType.RESPONSE_PARSER)
 public class ZhyDeepSeekParser implements ModelResponseParser {
 
     @Override

--- a/yml/src/main/java/ai/core/strategy/impl/parser/ZhyHainengParser.java
+++ b/yml/src/main/java/ai/core/strategy/impl/parser/ZhyHainengParser.java
@@ -5,7 +5,7 @@ import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.ModelResponseParser;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 /**
  * 中海油海能大模型响应解析器
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
  * @author hxdu5
  * @since 2025/7/12 21:17
  */
-@Component("中海油")
+@AiModelStrategy(modelType = "中海油", type = AiModelStrategy.StrategyType.RESPONSE_PARSER)
 public class ZhyHainengParser implements ModelResponseParser {
 
     @Override

--- a/yml/src/main/java/ai/core/strategy/impl/requestBody/DeepSeekRequestBodyBuilder.java
+++ b/yml/src/main/java/ai/core/strategy/impl/requestBody/DeepSeekRequestBodyBuilder.java
@@ -4,7 +4,7 @@ import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.RequestBodyBuilderStrategy;
 import com.iflytek.obu.mark.ai.utils.MapUtils;
 import com.iflytek.obu.mark.dto.ai.AiMessageDTO;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -18,7 +18,7 @@ import static com.iflytek.obu.mark.ai.utils.MapUtils.mapOf;
  * @author hxdu5
  * @since 2025/7/11 09:49
  */
-@Component
+@AiModelStrategy(modelType = "DeepSeek", type = AiModelStrategy.StrategyType.REQUEST_BODY_BUILDER)
 public class DeepSeekRequestBodyBuilder implements RequestBodyBuilderStrategy {
     @Override
     public boolean supports(ModelInfo modelInfo) {

--- a/yml/src/main/java/ai/core/strategy/impl/requestBody/ZhyDeepseekRequestBodyBuilder.java
+++ b/yml/src/main/java/ai/core/strategy/impl/requestBody/ZhyDeepseekRequestBodyBuilder.java
@@ -4,7 +4,7 @@ import com.iflytek.obu.mark.ai.config.ModelInfo;
 import com.iflytek.obu.mark.ai.core.strategy.RequestBodyBuilderStrategy;
 import com.iflytek.obu.mark.ai.utils.MapUtils;
 import com.iflytek.obu.mark.dto.ai.AiMessageDTO;
-import org.springframework.stereotype.Component;
+import ai.annotation.AiModelStrategy;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -13,7 +13,7 @@ import java.util.Map;
  * @author hxdu5
  * @since 2025/7/11 09:49
  */
-@Component
+@AiModelStrategy(modelType = "中海油-DS", type = AiModelStrategy.StrategyType.REQUEST_BODY_BUILDER)
 public class ZhyDeepseekRequestBodyBuilder implements RequestBodyBuilderStrategy {
     @Override
     public boolean supports(ModelInfo modelInfo) {


### PR DESCRIPTION
## Summary
- annotate strategy implementations with `@AiModelStrategy`
- centralize strategy retrieval in invoker classes via `AnnotationBasedModelStrategyFactory`

## Testing
- `mvn -q -f yml/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a01bb3c4832d96a88252320854df